### PR TITLE
gap makedoc.g generates VERSION file

### DIFF
--- a/makedoc.g
+++ b/makedoc.g
@@ -22,4 +22,6 @@ AutoDoc(
             )
 );
 
+PrintTo( "VERSION", PackageInfo( "CddInterface" )[1].Version );
+
 QUIT;


### PR DESCRIPTION
VERSION is now generated by `gap makedoc.g`. However, `make` requires it to build the binary, so there should be an independent way to generate it.